### PR TITLE
wait for a minute for workflow startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ function find_workflow {
     
     if [[ "$tdif" -gt "10" ]]
     then
-      if [[ "$counter" -gt "3" ]]
+      if [[ "$counter" -gt "30" ]]
       then
         echo "Workflow not found"
         exit 1


### PR DESCRIPTION
At the moment we are waiting for a maximum of 6 seconds for the startup of the
triggered GitHub workflow. Sometimes the workflow takes longer and we get
failed runs even though the triggered action succeeds.