### PR TITLE
make wait time for workflow startup configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Maximum amount of time to wait for workflow'
     default: "60"
     required: false
+  max_startup_time:
+    description: 'Maximum amount of time in seconds to wait for workflow startup'
+    default: "10"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ function find_workflow {
   counter=0
   while [[ true ]]
   do
-    counter=$(( $counter + 1 ))
+    counter=$(( $counter + 2 ))
     workflow=$(curl -s "https://api.github.com/repos/${INPUT_OWNER}/${INPUT_REPO}/actions/runs?event=repository_dispatch" \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: Bearer ${INPUT_TOKEN}" | jq '.workflow_runs[0]')
@@ -31,7 +31,7 @@ function find_workflow {
     
     if [[ "$tdif" -gt "10" ]]
     then
-      if [[ "$counter" -gt "3" ]]
+      if [[ "$counter" -gt "$INPUT_MAX_STARTUP_TIME" ]]
       then
         echo "Workflow not found"
         exit 1


### PR DESCRIPTION
At the moment we are waiting for a maximum of 6 seconds for the startup of the
triggered GitHub workflow. Sometimes the workflow takes longer and we get
failed runs even though the triggered action succeeds. Let us allow users
to configure the wait time to find a value that works for them.

This replaces #2.

P.S.: I had to create a new branch since I do not want to break the current implementation in master. 

- [ ] Tested